### PR TITLE
Lock only operations requests, these will be called concurrently. Stop

### DIFF
--- a/docker-rm/controllers/ResourceManager.py
+++ b/docker-rm/controllers/ResourceManager.py
@@ -150,7 +150,7 @@ class ResourceManager:
 		""" run transition on new or existing instance """
 		self.logger.debug('Resource Manager runTransition called with request\n\n '+str(transitionRequest)+'\n\n')
 		
-		self.rejectIfResourceBusy(transitionRequest)
+		# self.rejectIfResourceBusy(transitionRequest)
 			
 			
 		

--- a/docker-rm/controllers/transition/TransitionTasks.py
+++ b/docker-rm/controllers/transition/TransitionTasks.py
@@ -121,7 +121,14 @@ class TransitionTask(threading.Thread):
 					resp=self.resourceInstance.runStandardTransition(transitionName,self.transition.properties)
 				else:
 					self.logger.debug('running operation '+transitionName)
-					resp=self.resourceInstance.runOperation(transitionName,self.transition.properties)
+					with lock:
+						self.logger.debug('Locked for  transition '+ transitionName 
+						+ ' resource id: ' + str(self.transition.resourceId) 
+						+ ' request id: ' + str(self.transition.requestId))
+						resp=self.resourceInstance.runOperation(transitionName,self.transition.properties)
+						self.logger.debug('Unlocked for  transition '+ transitionName 
+						+ ' resource id: ' + str(self.transition.resourceId) 
+						+ ' request id: ' + str(self.transition.requestId))
 				self.logger.debug('marking transition COMPLETED')	
 				self.transition.requestState='COMPLETED'
 				self.transition.finishedAt=str(datetime.now(timezone.utc).astimezone().isoformat())


### PR DESCRIPTION
RM was rejecting all concurrent requests on  a resource . Operations may be called concurrently. Lifecycle actions should not be called concurrently. There is now a lock around operation requests, and no concurrent requests are rejected (including lifecycle transitions). 