### PR TITLE
Three fixes: metric_keys, system volumes, default properties

### DIFF
--- a/docker-rm/controllers/resource/ResourceInstance.py
+++ b/docker-rm/controllers/resource/ResourceInstance.py
@@ -179,7 +179,7 @@ class ResourceInstance:
 		
 		self.logger.debug('creating docker container for '+self.type.name)
 		volumeList=[]
-		#volumeList.append("/proc:/mnt/proc:ro")
+		volumeList.append("/sys/fs/cgroup:/sys/fs/cgroup:ro")
 		try:
 			self.container=dockerClient.containers.run(self.type.imageName,
 													name=self.type.imageName+str(self.resourceId),
@@ -187,8 +187,8 @@ class ResourceInstance:
 													hostname=hostname,
 													network=network,
 													detach=True,
-													privileged=True)#,
-													#volumes=volumeList)
+													privileged=True,
+													volumes=volumeList)
 		except (docker.errors.APIError, docker.errors.ContainerError) as ex:
 			# Need to check if a container was created and remove it if it was.
 			self.logger.error(str(ex))

--- a/docker-rm/controllers/transition/InstallTransitionTask.py
+++ b/docker-rm/controllers/transition/InstallTransitionTask.py
@@ -43,7 +43,10 @@ class InstallTransitionTask(TransitionTask):
 		#if super().validateStandardProperties(resourceType) ==False:
 		#	self.logger.error('missing properties')
 		#	raise MissingPropertiesException()
-
+		
+		# metric key is passed in all install requests
+		self.transition.properties['metricKey'] = transition.metricKey
+		
 		self.resourceInstance=controllers.ResourceManager.resourceManager.createNewResourceInstance(
 				resourceType,
 				self.transition.resourceName, 
@@ -51,7 +54,7 @@ class InstallTransitionTask(TransitionTask):
 				self.transition.properties
 				)
 		self.resourceId=self.resourceInstance.resourceId
-
+		
 		self.logger.debug('instance to be run='+str(self.resourceInstance.resourceId))
 
 	def run(self):

--- a/docker-rm/controllers/transition/TransitionTasks.py
+++ b/docker-rm/controllers/transition/TransitionTasks.py
@@ -56,15 +56,21 @@ class TransitionTask(threading.Thread):
 			transitionProperties = {}
 			
 		self.logger.debug('Properties to validate against descriptor: ' +str(transitionProperties))
-		
+		self.logger.debug('Properties from descriptor: ' + str(props))
 		if props==None:
 			self.logger.error('no properties found')
 			return False;
 
 		for p in props:
-			self.logger.debug('expecting '+str(props))
-			if 'default' in props[p]:
-				self.logger.debug('default value provided so pass')
+			self.logger.debug('validating '+str(p))
+			if 'default' in props[p] and p in transitionProperties:
+				self.logger.debug('default value overridden so pass')
+				pass
+			elif 'default' in props[p] and p not in transitionProperties:
+				self.logger.debug('default value for ' + str(p) 
+								+ ' not overridden, setting default value ' +  str(props[p]['default']) 
+								+ ' in transition properties')
+				transitionProperties[p] = props[p]['default']
 				pass
 			elif 'value' in props[p]:
 				self.logger.debug('value provided so pass')


### PR DESCRIPTION
pass metric_key to resource so resources can include in metrics sent on kafka
add volumes to docker run to use systemd so vnfs using startup scripts can be used.
set default  value for properties if not overridden.