### PR TITLE
Typo in variable name: eid --> id

### DIFF
--- a/docker-rm/controllers/util/DB.py
+++ b/docker-rm/controllers/util/DB.py
@@ -85,7 +85,7 @@ class DB:
 			i=self.transitionTable.get(eid=int(id))
 			self.logger.debug(i)
 		except Exception as ex:
-			self.logger.error('cannot find transition with eid '+str(eid))
+			self.logger.error('cannot find transition with eid '+str(id))
 			raise DBException(ex)
 		
 		return i


### PR DESCRIPTION
__eid__ is an _undefined name_ in this context but __id__ is a parameter to this function.

flake8 testing of https://github.com/IBM/osslm-docker-adaptor on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./docker-rm/controllers/util/DB.py:88:61: F821 undefined name 'eid'
			self.logger.error('cannot find transition with eid '+str(eid))
                                                            ^
1     F821 undefined name 'eid'
1
```